### PR TITLE
Add a vectorised classification method

### DIFF
--- a/classifier/base.py
+++ b/classifier/base.py
@@ -17,6 +17,9 @@ class BaseClassifier(object):
     def classify(self, predictors, **kwargs):
         raise NotImplementedError("function should be overloaded by subclass")
 
+    def vclassify(self, predictors, **kwargs):
+        raise NotImplementedError("function should be overloaded by subclass")
+
     def score(self, predictors, classifications, **kwargs):
         """
         Score the classifier's performance.
@@ -42,8 +45,11 @@ class BaseClassifier(object):
                              "number of classifications")
 
         model_classifications = np.zeros(N, dtype=int)
-        for index, object_predictors in enumerate(predictors):
-            model_classifications[index] = self.classify(object_predictors)
+        try:  # Try the vectorised version first
+            model_classifications = self.vclassify(predictors)
+        except (NotImplementedError, AttributeError):
+            for index, object_predictors in enumerate(predictors):
+                model_classifications[index] = self.classify(object_predictors)
 
         classifications = classifications.astype(int)
         is_transient = (classifications == 1)

--- a/classifier/classifier.py
+++ b/classifier/classifier.py
@@ -28,9 +28,32 @@ class Classifier(BaseClassifier):
         Classify a single object, given some predictors.
 
         :param predictors:
-            A row of predictors for a single object.
+            A row of predictors for a single object.
 
         :returns:
             A single-valued classification for this object.
         """
         return 0
+
+
+    def vclassify(self, predictors, **kwargs):
+        """
+        Classify a list of objects, given some predictors.
+
+        This classifier method takes precedence over `self.classify`,
+        provided it exists and is implemented.
+
+        This method is optional: if it's not implemented (or simply
+        does not exist), the classification is calculated by looping
+        over the classify method.
+
+        :param predictors:
+            An :class:`astropy.table.Table` of objects (rows) with
+            their predictors (columns).
+
+        :returns:
+            An array of classifications (0 or 1 integers) for the
+            input objects.
+        """
+        raise NotImplementedError
+        #return np.zeros(len(predictors), dtype=np.int)


### PR DESCRIPTION
This is somewhat of an ad-hoc work-around, and not the prettiest, as a solution to #4 .  
An overloaded function that accepts both a single row or a table may be nicer, but this
- makes it harder to unify the return value
- puts some burden on the implementers, as they may have to implement
  2 pathways to deal with the different kinds of input.

Alternatively, this can simply be implemented by the party that submits a new branch, but it does require changing `classifier/base.py` as well. Since `.ci/travis.sh` replaces `classifier/base.py` with the version from master for each run, this is less convenient (see https://github.com/GOTO-OBS/goto-vegas/tree/rol-randomforest).

I'm not sure if this is the way to go, so I'll put it in as PR just as food for thought.